### PR TITLE
Update version of the tool

### DIFF
--- a/src/package_validation_tool/package/validation.py
+++ b/src/package_validation_tool/package/validation.py
@@ -212,7 +212,7 @@ class SystemValidationResult(JsonSerializableMixin):
     """Result of analyzing all system packages."""
 
     report: Dict[str, PackageValidationResult]
-    version: str = "2024-10-05"
+    version: str = "2025-09-22"
 
 
 def validate_single_package(

--- a/test/test_srpm_archive_matching.py
+++ b/test/test_srpm_archive_matching.py
@@ -404,7 +404,7 @@ def test_validate_system_packages_cli():
             assert isinstance(system_output_data, dict)
             assert "report" in system_output_data
             assert "version" in system_output_data
-            assert system_output_data["version"] == "2024-10-05"
+            assert system_output_data["version"] == "2025-09-22"
             assert isinstance(system_output_data["report"], dict)
             assert len(system_output_data["report"]) > 0
 


### PR DESCRIPTION
Previously, the tool used "2024-10-05" version. Now that the tool is published on GitHub, let's bump the version to the current date: "2025-09-22". This version is added to the resulting JSON output in the sub-command "validate-system-packages" and is used to identify the version with which the package validation was performed.

Closes #1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
