### PR TITLE
Fix types like `notes: str = None` to have `Optional[str]`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,13 +65,14 @@ test =
     coverage>=7.0.0
 dev =
     black>=23.0.0
+    flake8>=7.0.0
     isort>=5.0.0
     mypy>=1.0.0
-    pylint>=3.0.0
-    flake8>=7.0.0
     pep8-naming>=0.13.0
-    sphinx>=7.0.0
+    pylint>=3.0.0
     sphinx-rtd-theme>=1.0.0
+    sphinx>=7.0.0
+    types-requests>=2.0.0
 
 [options.entry_points]
 console_scripts =

--- a/src/package_validation_tool/matching/autotools.py
+++ b/src/package_validation_tool/matching/autotools.py
@@ -667,7 +667,7 @@ class AutotoolsRunner:
             log.debug("File %s does not exist, will generate", filename)
             return True
 
-    def _run_autotools_command(self, command: str, env: dict, args: list = None) -> bool:
+    def _run_autotools_command(self, command: str, env: dict, args: Optional[list] = None) -> bool:
         """
         Run an Autotools command with proper environment.
 

--- a/src/package_validation_tool/operation_cache.py
+++ b/src/package_validation_tool/operation_cache.py
@@ -10,7 +10,7 @@ import os
 import shutil
 from dataclasses import asdict, is_dataclass
 from functools import wraps
-from typing import Any
+from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +82,9 @@ def load_return_value_from_cache_file(cache_file: str, func, cache_meta_data: di
     return cached_result
 
 
-def store_return_value_in_cache_file(cache_file: str, func, result, cache_meta_data: dict = None):
+def store_return_value_in_cache_file(
+    cache_file: str, func, result, cache_meta_data: Optional[dict] = None
+):
     """Store return value for a function in cache file."""
     log.debug(
         "Caching result for function %s to file %s",
@@ -109,12 +111,12 @@ class OperationCache:
     _instance = None
     _initialized = False
 
-    def __new__(cls, cache_directory: str = None, write_only: bool = False):
+    def __new__(cls, cache_directory: Optional[str] = None, write_only: bool = False):
         if cls._instance is None:
             cls._instance = super(OperationCache, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, cache_directory: str = None, write_only: bool = False):
+    def __init__(self, cache_directory: Optional[str] = None, write_only: bool = False):
         if not self._initialized:
             self.cache_directory = cache_directory
             self._calls = 0
@@ -199,7 +201,7 @@ class OperationCache:
         return f"From {self._calls} calls, {self._cached_results} have been cached ({percentage:.2f}%), using directory {self.cache_directory} {error_message}."
 
 
-def initialize_cache(cache_directory: str = None, write_only: bool = False) -> bool:
+def initialize_cache(cache_directory: Optional[str] = None, write_only: bool = False) -> bool:
     log.debug("Initializing OperationCache for directory %s", cache_directory)
     cache = OperationCache(cache_directory=cache_directory, write_only=write_only)
     cache_using_requested_dir = cache.cache_directory != cache_directory

--- a/src/package_validation_tool/package/__init__.py
+++ b/src/package_validation_tool/package/__init__.py
@@ -8,7 +8,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 # Packages with support right now
 SUPPORTED_PACKAGE_TYPES = ["rpm"]
@@ -82,7 +82,7 @@ class PackageResultMixin:
     """Mixin providing common package result fields."""
 
     matching: bool
-    source_package_name: str = None
+    source_package_name: Optional[str] = None
     archive_hashes: Dict[str, str] = field(default_factory=dict)
 
     # Package state indicators
@@ -108,9 +108,9 @@ class PackageResultMixin:
 class SuggestionMixin:
     """Mixin providing common suggestion fields."""
 
-    spec_source: str = None
-    suggested_by: str = None
-    notes: str = None
+    spec_source: Optional[str] = None
+    suggested_by: Optional[str] = None
+    notes: Optional[str] = None
     confidence: float = 0.00  # 0.00 .. 1.00
 
 
@@ -126,7 +126,7 @@ class UpstreamMatchingMixin:
 class RemoteArchiveResult(JsonSerializableMixin, FileMatchingStatsMixin, UpstreamMatchingMixin):
     """Result of matching a package local archive."""
 
-    remote_archive: str = None
+    remote_archive: Optional[str] = None
 
 
 @dataclass
@@ -148,12 +148,12 @@ class PackageRemoteArchivesResult(JsonSerializableMixin, PackageResultMixin):
 class RemoteRepoResult(JsonSerializableMixin, FileMatchingStatsMixin, UpstreamMatchingMixin):
     """Result of remote repo matching a package local archive."""
 
-    remote_repo: str = None
+    remote_repo: Optional[str] = None
 
     # particular version in the repo; tag may be empty/None (if corresponding version in the
     # repository is identified solely by the commit hash)
-    commit_hash: str = None
-    tag: str = None
+    commit_hash: Optional[str] = None
+    tag: Optional[str] = None
 
     # Autotools-related fields
     autotools_applied: bool = False

--- a/src/package_validation_tool/package/rpm/source_package.py
+++ b/src/package_validation_tool/package/rpm/source_package.py
@@ -135,7 +135,7 @@ class RPMSourcepackage:
     def __init__(
         self,
         package_name: str,
-        srpm_file: str = None,
+        srpm_file: Optional[str] = None,
         install_build_deps: InstallationDecision = InstallationDecision.NO,
     ):
         # note that some fields have "__" suffix, to ignore them in the cached object (as they have
@@ -449,7 +449,7 @@ class RPMSourcepackage:
     def match_remote_repos(
         self,
         suggested_repos: Dict[str, List[RemoteRepoSuggestion]],
-        autotools_dir: str = None,
+        autotools_dir: Optional[str] = None,
         apply_autotools: bool = True,
     ) -> PackageRemoteReposResult:
         """
@@ -702,7 +702,11 @@ class RPMSourcepackage:
         for archive_name, repos_list in matched_archives.items():
             if not any(repo.matched for repo in repos_list):
                 if repos_list:
-                    log.debug("Local archive %s has %d repo(s) but none matched successfully", archive_name, len(repos_list))
+                    log.debug(
+                        "Local archive %s has %d repo(s) but none matched successfully",
+                        archive_name,
+                        len(repos_list),
+                    )
                 else:
                     log.debug("Local archive %s does not have any matching repos", archive_name)
                 matching = False

--- a/src/package_validation_tool/package/rpm/utils.py
+++ b/src/package_validation_tool/package/rpm/utils.py
@@ -15,7 +15,7 @@ import tempfile
 from functools import lru_cache
 from pathlib import Path
 from subprocess import DEVNULL
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from package_validation_tool.utils import pushd, versions_is_greater
 
@@ -198,7 +198,9 @@ def get_package_providing_latest(package_name: str):
 
 
 def download_and_extract_source_package(
-    package_name: str, content_directory: str = "source_rpm_content", srpm_file: str = None
+    package_name: str,
+    content_directory: str = "source_rpm_content",
+    srpm_file: Optional[str] = None,
 ) -> Tuple[str, str]:
     """
     Download the source RPM file for the given package and extract the source files in CWD.
@@ -288,7 +290,7 @@ def get_env_with_home(new_home_var: str):
 
 
 def prepare_rpmbuild_source(
-    src_rpm_file: str, package_rpmbuild_home: str = None
+    src_rpm_file: str, package_rpmbuild_home: Optional[str] = None
 ) -> Tuple[str, str, str]:
     """
     Use an existing .src.rpm file, and prepare the source package for building.

--- a/src/package_validation_tool/package/suggesting_archives/__init__.py
+++ b/src/package_validation_tool/package/suggesting_archives/__init__.py
@@ -9,7 +9,7 @@ import os
 import pathlib
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from package_validation_tool.package import JsonSerializableMixin, SuggestionMixin
 
@@ -18,12 +18,12 @@ from package_validation_tool.package import JsonSerializableMixin, SuggestionMix
 class LocalArchiveTransformation:
     """Result of transforming local archives and corresponding spec Sources in the package."""
 
-    name: str = None
+    name: Optional[str] = None
     input_local_archives: List[str] = field(default_factory=list)
     input_spec_sources: List[str] = field(default_factory=list)
     output_local_archives: List[str] = field(default_factory=list)
     output_spec_sources: List[str] = field(default_factory=list)
-    notes: str = None
+    notes: Optional[str] = None
     confidence: float = 0.00  # 0.00 .. 1.00
 
 
@@ -31,7 +31,7 @@ class LocalArchiveTransformation:
 class RemoteArchiveSuggestion(JsonSerializableMixin, SuggestionMixin):
     """Result of suggesting a remote archive for a local archive in the package."""
 
-    remote_archive: str = None
+    remote_archive: Optional[str] = None
 
 
 @dataclass
@@ -46,7 +46,7 @@ class PackageRemoteArchivesSuggestions(JsonSerializableMixin):
     original and "transformed" lists will be identical.
     """
 
-    source_package_name: str = None
+    source_package_name: Optional[str] = None
 
     orig_local_archives: List[str] = field(default_factory=list)
     orig_spec_sources: List[str] = field(default_factory=list)
@@ -91,8 +91,8 @@ class PackageRemoteArchivesStats(JsonSerializableMixin):
 class Config:
     """Get configuration rules/patterns from `{transformations,suggestions}_*.json` files."""
 
-    _transformations_config: dict = None
-    _suggestions_config: dict = None
+    _transformations_config: Optional[dict] = None
+    _suggestions_config: Optional[dict] = None
 
     @staticmethod
     def _merge(a: dict, b: dict, path: list):
@@ -115,7 +115,7 @@ class Config:
     def _get_config(config_files_glob: str) -> dict:
         config_dir = pathlib.Path(os.environ.get("ENVROOT", ".")) / "configuration/"
 
-        config = dict()
+        config: dict = {}
         config_files = glob.glob(os.path.join(config_dir, config_files_glob))
         for filename in config_files:
             with open(filename, "r", encoding="utf-8") as f:

--- a/src/package_validation_tool/package/suggesting_archives/core.py
+++ b/src/package_validation_tool/package/suggesting_archives/core.py
@@ -12,7 +12,7 @@ by the user), find suggestions for remote archives, get statistics, etc.
 
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
 from package_validation_tool.operation_cache import disk_cached_operation
 from package_validation_tool.package import SUPPORTED_PACKAGE_TYPES
@@ -262,7 +262,7 @@ def _get_remote_archives_for_source_package(
 @disk_cached_operation
 def get_remote_archives_for_package(
     package_name: str,
-    srpm_file: str = None,
+    srpm_file: Optional[str] = None,
     package_type: str = "rpm",
     transform_archives: bool = False,
 ) -> PackageRemoteArchivesSuggestions:
@@ -296,8 +296,8 @@ def get_remote_archives_for_package(
 
 def suggest_remote_package_archives(
     package_name: str,
-    srpm_file: str = None,
-    output_json_path: str = None,
+    srpm_file: Optional[str] = None,
+    output_json_path: Optional[str] = None,
     package_type: str = "rpm",
     transform_archives: bool = False,
 ) -> bool:

--- a/src/package_validation_tool/package/suggesting_repos/__init__.py
+++ b/src/package_validation_tool/package/suggesting_repos/__init__.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from package_validation_tool.package import JsonSerializableMixin, SuggestionMixin
 
@@ -14,12 +14,12 @@ from package_validation_tool.package import JsonSerializableMixin, SuggestionMix
 class RemoteRepoSuggestion(JsonSerializableMixin, SuggestionMixin):
     """Result of suggesting a repo for a local archive in the package."""
 
-    repo: str = None
+    repo: Optional[str] = None
 
     # particular version in the repo; tag may be empty/None (if corresponding version in the
     # repository is identified solely by the commit hash)
-    commit_hash: str = None
-    tag: str = None
+    commit_hash: Optional[str] = None
+    tag: Optional[str] = None
 
 
 @dataclass
@@ -30,7 +30,7 @@ class PackageRemoteReposSuggestions(JsonSerializableMixin):
     Also contains a list of local archives and spec source lines, for convenience.
     """
 
-    source_package_name: str = None
+    source_package_name: Optional[str] = None
 
     local_archives: List[str] = field(default_factory=list)
 

--- a/src/package_validation_tool/package/suggesting_repos/core.py
+++ b/src/package_validation_tool/package/suggesting_repos/core.py
@@ -12,7 +12,7 @@ for (git) repos.
 import logging
 import os
 import shutil
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from package_validation_tool.operation_cache import disk_cached_operation
 from package_validation_tool.package import SUPPORTED_PACKAGE_TYPES
@@ -217,7 +217,7 @@ def _get_repos_for_source_package(
 @disk_cached_operation
 def get_repos_for_package(
     package_name: str,
-    srpm_file: str = None,
+    srpm_file: Optional[str] = None,
     package_type: str = "rpm",
 ) -> PackageRemoteReposSuggestions:
     """
@@ -249,8 +249,8 @@ def get_repos_for_package(
 
 def suggest_package_repos(
     package_name: str,
-    srpm_file: str = None,
-    output_json_path: str = None,
+    srpm_file: Optional[str] = None,
+    output_json_path: Optional[str] = None,
     package_type: str = "rpm",
 ) -> bool:
     """

--- a/src/package_validation_tool/package/validation.py
+++ b/src/package_validation_tool/package/validation.py
@@ -13,7 +13,7 @@ import random
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import partial
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from package_validation_tool.package import (
     SUPPORTED_PACKAGE_TYPES,
@@ -50,8 +50,8 @@ def store_package_content(
 
 def match_package_archives(
     package_name: str,
-    input_archives_json_path: str = None,
-    output_json_path: str = None,
+    input_archives_json_path: Optional[str] = None,
+    output_json_path: Optional[str] = None,
     package_type: str = "rpm",
 ) -> bool:
     """
@@ -113,10 +113,10 @@ def match_package_archives(
 
 def match_package_repos(
     package_name: str,
-    input_repos_json_path: str = None,
-    output_json_path: str = None,
+    input_repos_json_path: Optional[str] = None,
+    output_json_path: Optional[str] = None,
     package_type: str = "rpm",
-    autotools_dir: str = None,
+    autotools_dir: Optional[str] = None,
     apply_autotools: bool = True,
 ) -> bool:
     """
@@ -217,10 +217,10 @@ class SystemValidationResult(JsonSerializableMixin):
 
 def validate_single_package(
     package_name: str,
-    srpm_file: str = None,
+    srpm_file: Optional[str] = None,
     package_type: str = "rpm",
     install_build_deps: InstallationDecision = InstallationDecision.NO,
-    autotools_dir: str = None,
+    autotools_dir: Optional[str] = None,
     apply_autotools: bool = True,
 ) -> PackageValidationResult:
     """Analyze a single package and return the PackageValidationResult."""
@@ -319,11 +319,11 @@ def validate_single_package(
 
 def validate_package(
     package: str,
-    srpm_file: str = None,
+    srpm_file: Optional[str] = None,
     package_type: str = "rpm",
-    output_json_path: str = None,
+    output_json_path: Optional[str] = None,
     install_build_deps: InstallationDecision = InstallationDecision.NO,
-    autotools_dir: str = None,
+    autotools_dir: Optional[str] = None,
     apply_autotools: bool = True,
 ) -> bool:
     """Run analysis on a single package, and write report."""
@@ -348,11 +348,11 @@ def validate_package(
 
 def validate_system_packages(
     package_type: str = "rpm",
-    nr_packages_to_check: int = None,
-    output_json_path: str = None,
-    nr_processes: int = None,
-    extra_packages: List[str] = None,
-    autotools_dir: str = None,
+    nr_packages_to_check: Optional[int] = None,
+    output_json_path: Optional[str] = None,
+    nr_processes: Optional[int] = None,
+    extra_packages: Optional[List[str]] = None,
+    autotools_dir: Optional[str] = None,
     apply_autotools: bool = True,
 ) -> bool:
     """Run analysis on all (latest) packages on system, and write report."""

--- a/src/package_validation_tool/utils.py
+++ b/src/package_validation_tool/utils.py
@@ -181,7 +181,7 @@ def read_file_as_utf8(file_path: str) -> str:
     logging.getLogger("chardet").setLevel(chardet_level)
 
     # detect the encoding using chardet
-    detected_encoding: str = chardet.detect(content_bytes)["encoding"]
+    detected_encoding: Optional[str] = chardet.detect(content_bytes)["encoding"]
     if detected_encoding:
         try:
             content = content_bytes.decode(detected_encoding)
@@ -248,7 +248,9 @@ def versions_is_greater(left: str, right: str) -> bool:
     return len(left_parts) > len(right_parts)
 
 
-def clone_git_repo(repo: str, target_dir: str = None, bare: bool = False) -> Tuple[bool, str]:
+def clone_git_repo(
+    repo: str, target_dir: Optional[str] = None, bare: bool = False
+) -> Tuple[bool, str]:
     """
     Clone a git repository to a target directory.
 


### PR DESCRIPTION
PEP 484 made the Optional type explicit. The mypy tool (static type checker) started enforcing this rule in newer versions. This commit fixes all reported-by-mypy errors of this type, like this:

    `notes: str = None` -> `notes: Optional[str] = None`

Note that mypy checker still fails because of the other error types; they will be fixed in follow up commits.

This commit also adds the installation of types-requests module, which is a dependency of mypy.

See these:
- https://peps.python.org/pep-0484/#union-types
- https://github.com/python/mypy/issues/9091
- https://github.com/python/mypy/pull/13401

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
