### PR TITLE
Fix function return types like `str` to be `Optional[str]`

### DIFF
--- a/src/package_validation_tool/operation_cache.py
+++ b/src/package_validation_tool/operation_cache.py
@@ -70,7 +70,9 @@ def generate_hash_metadata(func_name, args, kwargs):
     return readable_key, cache_meta_data
 
 
-def load_return_value_from_cache_file(cache_file: str, func, cache_meta_data: dict) -> dict:
+def load_return_value_from_cache_file(
+    cache_file: str, func, cache_meta_data: dict
+) -> Optional[dict]:
     """Load return value for a function from cache file, if meta data matches."""
     log.debug("Loading cached result for function %s from file %s", func.__name__, cache_file)
     with open(cache_file, "r", encoding="utf-8") as f:

--- a/src/package_validation_tool/package/rpm/source_package.py
+++ b/src/package_validation_tool/package/rpm/source_package.py
@@ -783,7 +783,7 @@ class RPMSourcepackage:
             return []
         return self._spec.repourl_entries()
 
-    def get_name(self) -> str:
+    def get_name(self) -> Optional[str]:
         """
         Get name of the source package (value of the "Name" field in the package's spec file).
         """

--- a/src/package_validation_tool/package/rpm/utils.py
+++ b/src/package_validation_tool/package/rpm/utils.py
@@ -51,7 +51,7 @@ def get_system_install_tool() -> str:
     raise RuntimeError("No package installation tool found")
 
 
-def parse_rpm_spec_file(spec_file: str, fallback_plain_rpm: bool) -> str:
+def parse_rpm_spec_file(spec_file: str, fallback_plain_rpm: bool) -> Optional[str]:
     """Use 'rpmspec -P' to handle macros in a spec file, and return the flat content."""
 
     # if spec_file path has $RPM_HOME / "rpmbuild" / "SPEC" / *.spec, then set home to $RPM_HOME
@@ -201,7 +201,7 @@ def download_and_extract_source_package(
     package_name: str,
     content_directory: str = "source_rpm_content",
     srpm_file: Optional[str] = None,
-) -> Tuple[str, str]:
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Download the source RPM file for the given package and extract the source files in CWD.
     Returns a tuple with the location to the .src.rpm file and the directory with the package content

--- a/src/package_validation_tool/package/suggesting_archives/transformation_methods.py
+++ b/src/package_validation_tool/package/suggesting_archives/transformation_methods.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 import tarfile
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse, urlunparse
 
 from package_validation_tool.common import SUPPORTED_ARCHIVE_TYPES
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 def _transform_extract_nested_archives(
     local_archives: List[str], spec_sources: List[str]
-) -> LocalArchiveTransformation:
+) -> Optional[LocalArchiveTransformation]:
     """
     If there is a single archive file which contains only archive files (i.e., nested archives), and
     there is a single corresponding Source stanza, then replace the original `local_archives` and
@@ -96,7 +96,7 @@ def _transform_extract_nested_archives(
 
 def _transform_remove_url_fragment_from_spec_sources(
     local_archives: List[str], spec_sources: List[str]
-) -> LocalArchiveTransformation:
+) -> Optional[LocalArchiveTransformation]:
     """
     This transformation potentially modifies `spec_sources` (i.e., keeps `local_archives` as is).
     The transformation checks each Source: if it is a URL with a valid schema, then a URL fragment

--- a/src/package_validation_tool/package/suggesting_repos/version_utils.py
+++ b/src/package_validation_tool/package/suggesting_repos/version_utils.py
@@ -9,7 +9,7 @@ import subprocess
 from collections import namedtuple
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from package_validation_tool.matching.file_matching import SUPPORTED_ARCHIVE_TYPES
 
@@ -96,7 +96,7 @@ def is_release_tag(tag: str) -> bool:
     return True
 
 
-def find_best_matching_tag(archive: str, tags: List[TagInfo]) -> TagInfo:
+def find_best_matching_tag(archive: str, tags: List[TagInfo]) -> Optional[TagInfo]:
     """
     Find the tag that best matches the archive name.
 
@@ -286,7 +286,7 @@ def verify_tag_exists(
             archive = archive[: -len(ext)]
             break
 
-    def _handle_matching_tags(matching_tags: List[TagInfo]) -> Tuple[str, str]:
+    def _handle_matching_tags(matching_tags: List[TagInfo]) -> Optional[Tuple[str, str]]:
         if not matching_tags:
             return None
 
@@ -299,7 +299,7 @@ def verify_tag_exists(
     # Fetch all tags from the repository
     cmd = ["git", "tag", "--list", "--format=%(objectname) %(refname:short)"]
     try:
-        result = subprocess.run(
+        git_tag_list_result = subprocess.run(
             cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, cwd=repo_dir
         )
     except subprocess.CalledProcessError as e:
@@ -307,7 +307,7 @@ def verify_tag_exists(
         return "", ""
 
     # Split the output into lines
-    lines = result.stdout.strip().split("\n")
+    lines = git_tag_list_result.stdout.strip().split("\n")
     if not lines or lines[0] == "":
         log.warning("No tags found in repository directory %s", repo_dir)
         return "", ""

--- a/src/package_validation_tool/utils.py
+++ b/src/package_validation_tool/utils.py
@@ -109,7 +109,7 @@ def download_file(file_url: str, local_file_path: str):
     return False
 
 
-def extract_links(url: str) -> List[str]:
+def extract_links(url: str) -> Optional[List[str]]:
     """
     Scrape all links from the given URL (download and search for <a> HTML tags).
     Returns None in case of any exceptions (e.g., URL is inaccessible).


### PR DESCRIPTION
PEP 484 made the Optional type explicit, including as function return types. The mypy tool (static type checker) started enforcing this rule in newer versions. This commit fixes all reported-by-mypy errors of this type, like this:

    `def get_name() -> str` -> `def get_name() -> Optional[str]`

Note that mypy checker still fails because of the other error types; they will be fixed in follow up commits.

This commit also renames `result` -> `git_tag_list_result` because re-using `result` variable with two different types confuses mypy.

See these:
- https://peps.python.org/pep-0484/#union-types
- https://github.com/python/mypy/issues/9091
- https://github.com/python/mypy/pull/13401

This PR is on top of https://github.com/awslabs/package-validation-tool/pull/5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
