### PR TITLE
utils: Use `User-Agent: Wget/1.14 (linux-gnu)` when downloading files

### DIFF
--- a/src/package_validation_tool/utils.py
+++ b/src/package_validation_tool/utils.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 # Standard HTTP headers for web requests to avoid being blocked by websites
 # that filter requests with default user agents
-DEFAULT_REQUEST_HEADERS = {"User-Agent": "Mozilla/5.0 Firefox/140.0"}
+DEFAULT_REQUEST_HEADERS = {"User-Agent": "Wget/1.14 (linux-gnu)"}
 
 
 def set_default_python_socket_timeout():

--- a/test/system-level-testing.sh
+++ b/test/system-level-testing.sh
@@ -340,10 +340,12 @@ test_repology_website_structure() {
 
     # Download the page: Repology requires TLS v1.2, which is NOT available on Amazon Linux 2, so
     # the download may fail (we ignore this issue because this should succeed on newer Amazon Linux)
-    if ! curl -A "Mozilla/5.0 Firefox/140.0" -s -f "$url" -o "$temp_file"; then
-        echo "WARNING: Failed to fetch Repology page: $url"
+    if ! curl -A "Wget/1.14 (linux-gnu)" -s -f "$url" -o "$temp_file"; then
+        echo "WARNING: Failed to fetch Repology page: $url, skipping this test ..."
         return 0
     fi
+
+    echo "Test Repology website structure for example URL $url ..."
 
     # Check if Repository_links section exists
     if ! grep -q 'id="Repository_links"' "$temp_file"; then


### PR DESCRIPTION
Previously, our tool pretended to be the Firefox web browser to websites when downloading files (in particular source tarballs). This was achieved by setting user-agent HTTP header field to "Mozilla/5.0 Firefox/140.0". This is generally wrong: ideally the tool must state its own name, not pretend to be something else; however in this case some websites refuse to allow the download. But more practically, pretending to be a Firefox web browser results in some websites redirecting to an interactive web page, instead of just downloading the requested file. This was detected on the OpenSSH tarball URL: http://pamsshagentauth/pam_ssh_agent_auth.

To stop such behavior of some web sites, this commit stops the practice of pretending to be a web browser and instead pretends to be a wget utility.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
