### PR TITLE
[suggesting] Use name of source package if archive has only version

### DIFF
--- a/src/package_validation_tool/package/suggesting_archives/core.py
+++ b/src/package_validation_tool/package/suggesting_archives/core.py
@@ -128,10 +128,15 @@ class RemotePackageArchivesSuggester:
         local_archive_basename = os.path.basename(local_archive)
         log.info("Suggesting remote archives for %s", local_archive_basename)
 
+        # Create package dictionary to pass to suggestion methods
+        package = {
+            "source_package_name": self._suggestion_result.source_package_name,
+        }
+
         suggested_remote_archives = []  # list of RemoteArchiveSuggestion objects
         for suggestion_method in SUGGESTION_METHODS:
             suggested_remote_archives.extend(
-                suggestion_method(local_archive_basename, self._spec_sources)
+                suggestion_method(package, local_archive_basename, self._spec_sources)
             )
 
         assert local_archive_basename not in self._suggestion_result.suggestions

--- a/src/package_validation_tool/package/suggesting_archives/suggestion_methods.py
+++ b/src/package_validation_tool/package/suggesting_archives/suggestion_methods.py
@@ -6,11 +6,13 @@ List of methods to suggest remote archives' URLs for local archives.
 
 Each function in this module has the following function signature:
 
-  def _suggest_*(local_archive_basename: str, spec_sources: list[str]) -> list[RemoteArchiveSuggestion]
+  def _suggest_*(package: dict[str, Any], local_archive_basename: str, spec_sources: list[str]) -> list[RemoteArchiveSuggestion]
 
-Each function takes a locally extracted-from-srpm archive and the corresponding list of this
-archive's URLs from Source stanzas in the spec file and tries one specific heuristic to find
-accessible URLs with matching remote archives.
+Each function takes a package dictionary (containing at least source_package_name), a locally
+extracted-from-srpm archive and the corresponding list of this archive's URLs from Source stanzas
+in the spec file and tries one specific heuristic to find accessible URLs with matching remote archives.
+Note that the `package` argument is not currently used by any function in this module, but is
+included for future extensibility.
 
 Each function returns a list of RemoteArchiveSuggestion objects (with the most important field being
 `remote_archive` full URL). Typically, the returned list contains only one such object. If no
@@ -24,7 +26,7 @@ local archive can be matched to multiple URLs, then the returned list contains a
 import inspect
 import logging
 import os
-from typing import List
+from typing import Any, Dict, List
 from urllib.parse import urlparse, urlunparse
 
 from package_validation_tool.common import SUPPORTED_ARCHIVE_TYPES
@@ -35,7 +37,7 @@ log = logging.getLogger(__name__)
 
 
 def _suggest_remote_archive_from_spec_sources_exact(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find the Source stanza(s) in spec_sources that match the basename of the local_archive and
@@ -62,7 +64,7 @@ def _suggest_remote_archive_from_spec_sources_exact(
 
 
 def _suggest_remote_archive_from_spec_sources_sep_version(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find the Source stanza(s) in spec_sources that match the name + version of the local_archive and
@@ -102,7 +104,7 @@ def _suggest_remote_archive_from_spec_sources_sep_version(
 
 
 def _suggest_remote_archive_from_spec_sources_ftp_to_https(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find FTP-based Source stanza(s) in spec_sources that match the basename of the local_archive,
@@ -137,7 +139,7 @@ def _suggest_remote_archive_from_spec_sources_ftp_to_https(
 
 
 def _suggest_remote_archive_from_known_urls_exact(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find the archive among known URLs and return the list of corresponding RemoteArchiveSuggestion
@@ -170,7 +172,7 @@ def _suggest_remote_archive_from_known_urls_exact(
 
 
 def _suggest_remote_archive_that_was_moved_and_recompressed(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find the archive that has a valid-looking but inaccessible Source stanza, by assuming that the
@@ -220,7 +222,7 @@ def _suggest_remote_archive_that_was_moved_and_recompressed(
 
 
 def _suggest_remote_archive_from_another_subdomain_url(
-    local_archive_basename: str, spec_sources: List[str]
+    _: Dict[str, Any], local_archive_basename: str, spec_sources: List[str]
 ) -> List[RemoteArchiveSuggestion]:
     """
     Find the archive that has a valid-looking but inaccessible Source stanza, by assuming that the

--- a/src/package_validation_tool/package/suggesting_repos/core.py
+++ b/src/package_validation_tool/package/suggesting_repos/core.py
@@ -106,9 +106,16 @@ class RepoSuggester:
         local_archive_basename = os.path.basename(local_archive)
         log.info("Suggesting repos for archive %s", local_archive_basename)
 
+        # Create package dictionary to pass to suggestion methods
+        package = {
+            "source_package_name": self._suggestion_result.source_package_name,
+        }
+
         suggested_repos = []  # list of RemoteRepoSuggestion objects
         for suggestion_method in SUGGESTION_METHODS:
-            suggested_repos.extend(suggestion_method(local_archive_basename, self._spec_sources))
+            suggested_repos.extend(
+                suggestion_method(package, local_archive_basename, self._spec_sources)
+            )
 
         if local_archive_basename in self._suggestion_result.suggestions:
             raise RuntimeError(

--- a/test/test_suggestion_methods.py
+++ b/test/test_suggestion_methods.py
@@ -33,8 +33,11 @@ def test_suggest_remote_archive_from_spec_sources_exact():
         "package_validation_tool.package.suggesting_archives.suggestion_methods.is_url_accessible",
         patched_is_url_accessible,
     ):
+        # Create mock package dictionary
+        package = {"source_package_name": "archive"}
+
         remote_archive_results = _suggest_remote_archive_from_spec_sources_exact(
-            local_archive_basename, spec_sources
+            package, local_archive_basename, spec_sources
         )
 
         assert len(remote_archive_results) == 3
@@ -66,8 +69,11 @@ def test_suggest_remote_archive_from_spec_sources_sep_version():
         "package_validation_tool.package.suggesting_archives.suggestion_methods.is_url_accessible",
         patched_is_url_accessible,
     ):
+        # Create mock package dictionary
+        package = {"source_package_name": "archive"}
+
         remote_archive_results = _suggest_remote_archive_from_spec_sources_sep_version(
-            local_archive_basename, spec_sources
+            package, local_archive_basename, spec_sources
         )
 
         assert len(remote_archive_results) == 3
@@ -91,8 +97,11 @@ def test_suggest_remote_archive_from_spec_sources_ftp_to_https():
         "package_validation_tool.package.suggesting_archives.suggestion_methods.is_url_accessible",
         patched_is_url_accessible,
     ):
+        # Create mock package dictionary
+        package = {"source_package_name": "archive"}
+
         remote_archive_results = _suggest_remote_archive_from_spec_sources_ftp_to_https(
-            local_archive_basename, spec_sources.keys()
+            package, local_archive_basename, spec_sources.keys()
         )
 
         assert len(remote_archive_results) == 2


### PR DESCRIPTION
Previously, the "suggesting repos" logic relied on the basename of the local archive to contain both the software project name and its version, for example "zlib-1.2.11.tar.gz". Sometimes the archive doesn't contain the project name but only the version, for example "v2.2.0.tar.gz" (e.g., this is typically how GitHub publishes release artifacts). In such cases, the tool searched for a bogus upstream repo "v" and failed to find any matches.

This commit fixes this corner case by using the name of the source package instead of the archive when calling suggestion methods, if the local archive seems to have only the version. For example, if local archive is "v2.2.0.tar.gz", then the source package name ("ec2-utils") is used instead.

This commit also modifies the "suggesting archives" logic in the same way. However, there are no suggestion methods that would need this currently, so this is purely for future extensibility.

Fixes https://github.com/awslabs/package-validation-tool/issues/14.

Closes #16 (this PR is an alternative implementation of that one, as requested by @nmanthey)

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
