### PR TITLE
[DONTMERGE] matching: use libtool v2.6.4 as shipped in Arch Linux

### DIFF
--- a/configuration/external_patches/README
+++ b/configuration/external_patches/README
@@ -2,3 +2,6 @@ Patches are taken from:
 
 - autoconf-2.69-backport-runstatedir-option.patch (GNU GPL license):
   https://src.fedoraproject.org/rpms/autoconf/raw/f34/f/autoconf-2.69-backport-runstatedir-option.patch
+
+- libtool-2.4.6-no_hostname.patch (GNU GPLv2 license):
+  https://gitlab.archlinux.org/archlinux/packaging/packages/libtool/-/blob/2.4.6+42+gb88cebd5-16/no_hostname.patch

--- a/configuration/external_patches/libtool-2.4.6-no_hostname.patch
+++ b/configuration/external_patches/libtool-2.4.6-no_hostname.patch
@@ -1,0 +1,13 @@
+Index: libtool-2.4.6/m4/libtool.m4
+===================================================================
+--- libtool-2.4.6.orig/m4/libtool.m4
++++ libtool-2.4.6/m4/libtool.m4
+@@ -728,7 +728,6 @@ _LT_CONFIG_SAVE_COMMANDS([
+     cat <<_LT_EOF >> "$cfgfile"
+ #! $SHELL
+ # Generated automatically by $as_me ($PACKAGE) $VERSION
+-# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
+ # NOTE: Changes made to this file will be lost: look at ltmain.sh.
+ 
+ # Provide generalized library-building support services.
+

--- a/misc/AL2-Dockerfile
+++ b/misc/AL2-Dockerfile
@@ -14,13 +14,14 @@ RUN yum install -y \
 
 # Typical package build dependencies
 RUN yum install -y \
-    automake \
     autoconf \
+    automake \
     gcc \
-    git \
     gettext \
     gettext-devel \
+    git \
     gnupg2 \
+    help2man \
     libtool \
     make
 

--- a/misc/AL2023-Dockerfile
+++ b/misc/AL2023-Dockerfile
@@ -12,13 +12,14 @@ RUN dnf install -y \
 
 # Typical package build dependencies, and replace gnupg minimal with gnupg
 RUN dnf install -y  --allowerasing \
-    automake \
     autoconf \
+    automake \
     gcc \
-    git \
     gettext \
     gettext-devel \
+    git \
     gnupg2 \
+    help2man \
     libtool \
     make
 

--- a/misc/Fedora40-Dockerfile
+++ b/misc/Fedora40-Dockerfile
@@ -14,13 +14,14 @@ RUN dnf install -y \
 
 # Typical package build dependencies
 RUN dnf install -y \
-    automake \
     autoconf \
+    automake \
     gcc \
-    git \
     gettext \
     gettext-devel \
+    git \
     gnupg2 \
+    help2man \
     libtool \
     make
 


### PR DESCRIPTION
This is a **hacky commit** to explore what it takes to reproduce the Autotools-generated files in the xz-5.2.5.tar.xz tarball (xz utils software project). The xz tarball is known to be generated on (some version) of Arch Linux and uses ArchLinux-specific version of libtool. See how libtool is patched and built on Arch Linux here: https://gitlab.archlinux.org/archlinux/packaging/packages/libtool/-/tree/2.4.6+42+gb88cebd5-16

With these changes, xz's autotools-generated files are reproducible. The only exceptions are `Changelog` (in the official repo, this file exists and has a dummy text, so our tool doesn't try to regenerate it) and `po` (PO files, used for translations) which are non-reproducible generally.

---

Test like this in a AL2023 Docker container:
```
PVT_FILE_MATCHER_DIFFS_PATH=./xz-diff-files/ \
  package-validation-tool match-package-repos -p xz -o xz-match-repos.json
```

It will report the following:
```
Matching local archive xz-5.2.5.tar.xz with remote repo https://github.com/tukaani-project/xz and commit/tag v5.2.5
Saving differing files in ./xz-diff-files/xz/xz-5.2.5.tar.xz
Stats: 486 files total, 429 matching (88.27%), 14 different (2.88%), 43 no counterpart (8.85%)
```

Let's look into `xz-diff-files/`:
```
$ tree xz-diff-files/

xz-diff-files/
`-- xz
    `-- xz-5.2.5.tar.xz
        |-- ChangeLog.arch
        |-- ChangeLog.repo
        |-- po
        |   |-- cs.po.arch
        |   |-- cs.po.repo
        |   |    ...
        |   |-- zh_TW.po.arch
        |   `-- zh_TW.po.repo
        `-- po4a
            |-- de.po.arch
            `-- de.po.repo
```

You can examine the residual differences between arch (local archive) and repo (upstream repo) files like this:
```
vimdiff xz-diff-files/xz/xz-5.2.5.tar.xz/ChangeLog.*
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
