### PR TITLE
Archive gap diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ package-validation-tool match-package-repos -p zlib -o zlib-match-repos.json
 
 # 4. Run full validation on all packages on the system
 package-validation-tool validate-system-packages -o all-system-packages.json
+
+# 5. Compare diffs between two package versions (see docs/compare-diffs.md)
+package-validation-tool validate-package -p curl-8.0.1 -o v1.json --diffs-path diffs/
+package-validation-tool validate-package -p curl-8.2.1 -o v2.json --diffs-path diffs/
+package-validation-tool compare-diffs \
+    --dir-a diffs/curl-8.0.1-*/curl-8.0.1.tar.xz \
+    --dir-b diffs/curl-8.2.1-*/curl-8.2.1.tar.xz \
+    -o comparison.json
+
+# 5b. Compare with normalization (ignore date/version string differences)
+package-validation-tool compare-diffs \
+    --dir-a diffs/curl-8.0.1-*/curl-8.0.1.tar.xz \
+    --dir-b diffs/curl-8.2.1-*/curl-8.2.1.tar.xz \
+    --normalize-dates --normalize-versions \
+    --output-diffs diff-of-diffs/ \
+    -o comparison-normalized.json
 ```
 
 **Notes on Docker**

--- a/src/package_validation_tool/cli.py
+++ b/src/package_validation_tool/cli.py
@@ -373,6 +373,11 @@ def add_compare_diffs_parser(parent):
         action="store_true",
         help="Ignore version string differences when comparing files",
     )
+    parser.add_argument(
+        "--output-diffs",
+        type=str,
+        help="Directory to write diff-of-diffs for files with different content",
+    )
     add_output_json_parameter(parser)
 
 

--- a/src/package_validation_tool/cli.py
+++ b/src/package_validation_tool/cli.py
@@ -14,6 +14,7 @@ import argparse
 import logging
 import sys
 
+from package_validation_tool.matching.diff_comparison import compare_diffs_directories
 from package_validation_tool.matching.file_matching import match_files
 from package_validation_tool.operation_cache import initialize_cache, manage_cache
 from package_validation_tool.package import SUPPORTED_PACKAGE_TYPES, InstallationDecision
@@ -276,6 +277,12 @@ def add_package_validation_parser(parent):
     add_package_type_parameter(parser)
     add_output_json_parameter(parser)
     add_autotools_parameters(parser)
+    parser.add_argument(
+        "--diffs-path",
+        type=str,
+        default=None,
+        help="Directory to store file diffs (overrides PVT_FILE_MATCHER_DIFFS_PATH env var)",
+    )
 
 
 def add_system_validation_parser(parent):
@@ -329,6 +336,36 @@ def add_cache_parser(parent):
     )
 
 
+def add_compare_diffs_parser(parent):
+    """Create parser for comparing two diffs directories."""
+
+    parser = parent.add_parser(
+        "compare-diffs",
+        description=compare_diffs_directories.__doc__,
+    )
+    parser.set_defaults(command=compare_diffs_directories)
+
+    parser.add_argument(
+        "--dir-a",
+        type=str,
+        required=True,
+        help="First diffs directory to compare",
+    )
+    parser.add_argument(
+        "--dir-b",
+        type=str,
+        required=True,
+        help="Second diffs directory to compare",
+    )
+    parser.add_argument(
+        "-p",
+        "--package-name",
+        type=str,
+        help="Package name to filter comparison (optional)",
+    )
+    add_output_json_parameter(parser)
+
+
 def parse_args(given_args=None):
     """Parse args to be compatible with the used clients, return as dict."""
 
@@ -366,6 +403,7 @@ def parse_args(given_args=None):
     add_system_validation_parser(subparsers)
     add_package_store_parser(subparsers)
     add_cache_parser(subparsers)
+    add_compare_diffs_parser(subparsers)
 
     return vars(parser.parse_args(given_args))
 

--- a/src/package_validation_tool/cli.py
+++ b/src/package_validation_tool/cli.py
@@ -363,6 +363,16 @@ def add_compare_diffs_parser(parent):
         type=str,
         help="Package name to filter comparison (optional)",
     )
+    parser.add_argument(
+        "--normalize-dates",
+        action="store_true",
+        help="Ignore date differences when comparing files",
+    )
+    parser.add_argument(
+        "--normalize-versions",
+        action="store_true",
+        help="Ignore version string differences when comparing files",
+    )
     add_output_json_parameter(parser)
 
 

--- a/src/package_validation_tool/matching/diff_comparison.py
+++ b/src/package_validation_tool/matching/diff_comparison.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module to compare diffs directories from two package validation runs."""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from package_validation_tool.package import JsonSerializableMixin
+from package_validation_tool.utils import hash256sum
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ArchiveDiffComparison:
+    """Comparison result for a single archive's diffs."""
+
+    files_only_in_a: List[str] = field(default_factory=list)
+    files_only_in_b: List[str] = field(default_factory=list)
+    files_with_different_content: List[str] = field(default_factory=list)
+
+    @property
+    def identical(self) -> bool:
+        """Return True if no differences found."""
+        return not (
+            self.files_only_in_a or self.files_only_in_b or self.files_with_different_content
+        )
+
+
+@dataclass
+class DiffComparisonResult(JsonSerializableMixin):
+    """Result of comparing two diffs directories."""
+
+    identical: bool
+    package_name: str
+    archives_compared: List[str] = field(default_factory=list)
+    differences: Dict[str, ArchiveDiffComparison] = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Reconstruct nested dataclass objects from dicts after cache restoration."""
+        for archive, diff in list(self.differences.items()):
+            if isinstance(diff, dict):
+                self.differences[archive] = ArchiveDiffComparison(**diff)
+
+
+def _get_diff_files(directory: Path) -> Dict[str, str]:
+    """
+    Get all .arch and .repo files in directory, returning dict of relative path -> absolute path.
+
+    Only returns the base path (without .arch/.repo suffix) as key.
+    """
+    files = {}
+    for root, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if filename.endswith((".arch", ".repo")):
+                abs_path = os.path.join(root, filename)
+                rel_path = os.path.relpath(abs_path, directory)
+                # Remove .arch/.repo suffix for comparison key
+                base_path = rel_path.rsplit(".", 1)[0]
+                files[base_path] = abs_path
+    return files
+
+
+def compare_diffs_directories(
+    dir_a: str,
+    dir_b: str,
+    package_name: Optional[str] = None,
+    output_json_path: Optional[str] = None,
+) -> bool:
+    """
+    Compare two diffs directories to check if package-to-upstream differences are identical.
+
+    Args:
+        dir_a: First diffs directory path
+        dir_b: Second diffs directory path
+        package_name: Optional package name to filter comparison
+        output_json_path: Optional path to write JSON output
+
+    Returns:
+        True if diffs are identical, False otherwise
+    """
+    path_a = Path(dir_a)
+    path_b = Path(dir_b)
+
+    if not path_a.exists():
+        log.error("Directory does not exist: %s", dir_a)
+        return False
+    if not path_b.exists():
+        log.error("Directory does not exist: %s", dir_b)
+        return False
+
+    # If package_name specified, narrow to that subdirectory
+    if package_name:
+        path_a = path_a / package_name
+        path_b = path_b / package_name
+
+        if not path_a.exists():
+            log.warning("Package directory does not exist in dir_a: %s", path_a)
+        if not path_b.exists():
+            log.warning("Package directory does not exist in dir_b: %s", path_b)
+
+    # Get all diff files from both directories
+    files_a = _get_diff_files(path_a) if path_a.exists() else {}
+    files_b = _get_diff_files(path_b) if path_b.exists() else {}
+
+    all_files = set(files_a.keys()) | set(files_b.keys())
+
+    # Group files by archive
+    archives: Dict[str, ArchiveDiffComparison] = {}
+
+    for file_path in sorted(all_files):
+        # Extract archive name from path (first component)
+        parts = file_path.split(os.sep)
+        archive_name = parts[0] if parts else "unknown"
+
+        if archive_name not in archives:
+            archives[archive_name] = ArchiveDiffComparison()
+
+        in_a = file_path in files_a
+        in_b = file_path in files_b
+
+        if in_a and not in_b:
+            archives[archive_name].files_only_in_a.append(file_path)
+        elif in_b and not in_a:
+            archives[archive_name].files_only_in_b.append(file_path)
+        else:
+            # Both exist, compare content via hash
+            hash_a = hash256sum(files_a[file_path])
+            hash_b = hash256sum(files_b[file_path])
+            if hash_a != hash_b:
+                archives[archive_name].files_with_different_content.append(file_path)
+
+    identical = all(diff.identical for diff in archives.values())
+
+    result = DiffComparisonResult(
+        identical=identical,
+        package_name=package_name or "",
+        archives_compared=list(archives.keys()),
+        differences=archives,
+    )
+
+    log.info(
+        "Compared %d archives, identical: %s",
+        len(archives),
+        identical,
+    )
+
+    if output_json_path:
+        result.write_json_output(output_json_path)
+
+    return identical

--- a/src/package_validation_tool/matching/diff_comparison.py
+++ b/src/package_validation_tool/matching/diff_comparison.py
@@ -5,12 +5,43 @@
 
 import logging
 import os
+import re
+import secrets
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from package_validation_tool.package import JsonSerializableMixin
 from package_validation_tool.utils import hash256sum
+
+# Patterns for date normalization
+DATE_PATTERNS = [
+    # Spelled-out dates: January 02, 2023 / Apr 26, 2023
+    re.compile(
+        r"\b(?:January|February|March|April|May|June|July|August|September|October"
+        r"|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"
+        r"\s+\d{1,2},?\s*\d{4}\b"
+    ),
+    # ISO dates: 2024-01-26, 2023-07-19
+    re.compile(r"\b\d{4}-\d{2}-\d{2}\b"),
+    # Year ranges: 2020-2021, 2021-2024
+    re.compile(r"\b(19|20)\d{2}-(19|20)\d{2}\b"),
+    # Standalone years: 2024, 2023
+    re.compile(r"\b(19|20)\d{2}\b"),
+]
+
+
+def _generate_placeholder() -> str:
+    """Generate a random placeholder string to avoid injection attacks."""
+    return f"__PLACEHOLDER_{secrets.token_hex(16)}__"
+
+
+def _extract_version_from_path(path: str) -> Optional[str]:
+    """Extract version string from a diffs directory path like 'xz-5.4.6.tar.gz'."""
+    # Match patterns like package-1.2.3.tar.gz or package-1.2.3
+    match = re.search(r"-(\d+\.\d+(?:\.\d+)*)(?:\.tar|\.zip|$)", path)
+    return match.group(1) if match else None
+
 
 log = logging.getLogger(__name__)
 
@@ -65,11 +96,60 @@ def _get_diff_files(directory: Path) -> Dict[str, str]:
     return files
 
 
+def _normalize_dates(content: str, placeholder: str) -> str:
+    """Replace date patterns with placeholder for comparison."""
+    for pattern in DATE_PATTERNS:
+        content = pattern.sub(placeholder, content)
+    return content
+
+
+def _normalize_versions(content: str, versions: List[str], placeholder: str) -> str:
+    """Replace version strings with placeholder for comparison."""
+    for version in versions:
+        if version:
+            content = content.replace(version, placeholder)
+    return content
+
+
+def _read_and_normalize(
+    file_path: str,
+    normalize_dates: bool,
+    versions: Optional[List[str]] = None,
+    placeholder: str = "",
+) -> str:
+    """Read file content and optionally normalize dates and versions."""
+    with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+        content = f.read()
+    if normalize_dates:
+        content = _normalize_dates(content, placeholder)
+    if versions:
+        content = _normalize_versions(content, versions, placeholder)
+    return content
+
+
+def _compare_files(
+    path_a: str,
+    path_b: str,
+    normalize_dates: bool,
+    versions: Optional[List[str]] = None,
+) -> bool:
+    """Compare two files, return True if identical (after optional normalization)."""
+    if not normalize_dates and not versions:
+        return hash256sum(path_a) == hash256sum(path_b)
+    # Use same random placeholder for both files in this comparison
+    placeholder = _generate_placeholder()
+    content_a = _read_and_normalize(path_a, normalize_dates, versions, placeholder)
+    content_b = _read_and_normalize(path_b, normalize_dates, versions, placeholder)
+    return content_a == content_b
+
+
 def compare_diffs_directories(
     dir_a: str,
     dir_b: str,
     package_name: Optional[str] = None,
     output_json_path: Optional[str] = None,
+    normalize_dates: bool = False,
+    normalize_versions: bool = False,
 ) -> bool:
     """
     Compare two diffs directories to check if package-to-upstream differences are identical.
@@ -79,6 +159,8 @@ def compare_diffs_directories(
         dir_b: Second diffs directory path
         package_name: Optional package name to filter comparison
         output_json_path: Optional path to write JSON output
+        normalize_dates: If True, ignore date differences when comparing
+        normalize_versions: If True, ignore version string differences when comparing
 
     Returns:
         True if diffs are identical, False otherwise
@@ -107,6 +189,15 @@ def compare_diffs_directories(
     files_a = _get_diff_files(path_a) if path_a.exists() else {}
     files_b = _get_diff_files(path_b) if path_b.exists() else {}
 
+    # Extract versions from directory paths for normalization
+    versions: Optional[List[str]] = None
+    if normalize_versions:
+        version_a = _extract_version_from_path(dir_a)
+        version_b = _extract_version_from_path(dir_b)
+        versions = [v for v in [version_a, version_b] if v]
+        if versions:
+            log.info("Normalizing version strings: %s", versions)
+
     all_files = set(files_a.keys()) | set(files_b.keys())
 
     # Group files by archive
@@ -128,10 +219,10 @@ def compare_diffs_directories(
         elif in_b and not in_a:
             archives[archive_name].files_only_in_b.append(file_path)
         else:
-            # Both exist, compare content via hash
-            hash_a = hash256sum(files_a[file_path])
-            hash_b = hash256sum(files_b[file_path])
-            if hash_a != hash_b:
+            # Both exist, compare content
+            if not _compare_files(
+                files_a[file_path], files_b[file_path], normalize_dates, versions
+            ):
                 archives[archive_name].files_with_different_content.append(file_path)
 
     identical = all(diff.identical for diff in archives.values())

--- a/src/package_validation_tool/matching/diff_comparison.py
+++ b/src/package_validation_tool/matching/diff_comparison.py
@@ -3,6 +3,7 @@
 
 """Module to compare diffs directories from two package validation runs."""
 
+import difflib
 import logging
 import os
 import re
@@ -143,6 +144,18 @@ def _compare_files(
     return content_a == content_b
 
 
+def _write_diff(path_a: str, path_b: str, output_path: Path) -> None:
+    """Write unified diff between two files to output_path."""
+    with open(path_a, "r", encoding="utf-8", errors="replace") as f:
+        lines_a = f.readlines()
+    with open(path_b, "r", encoding="utf-8", errors="replace") as f:
+        lines_b = f.readlines()
+    diff = difflib.unified_diff(lines_a, lines_b, fromfile=path_a, tofile=path_b)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.writelines(diff)
+
+
 def compare_diffs_directories(
     dir_a: str,
     dir_b: str,
@@ -150,6 +163,7 @@ def compare_diffs_directories(
     output_json_path: Optional[str] = None,
     normalize_dates: bool = False,
     normalize_versions: bool = False,
+    output_diffs: Optional[str] = None,
 ) -> bool:
     """
     Compare two diffs directories to check if package-to-upstream differences are identical.
@@ -161,6 +175,7 @@ def compare_diffs_directories(
         output_json_path: Optional path to write JSON output
         normalize_dates: If True, ignore date differences when comparing
         normalize_versions: If True, ignore version string differences when comparing
+        output_diffs: Optional directory to write diff-of-diffs for differing files
 
     Returns:
         True if diffs are identical, False otherwise
@@ -224,6 +239,9 @@ def compare_diffs_directories(
                 files_a[file_path], files_b[file_path], normalize_dates, versions
             ):
                 archives[archive_name].files_with_different_content.append(file_path)
+                if output_diffs:
+                    diff_path = Path(output_diffs) / f"{file_path}.diff"
+                    _write_diff(files_a[file_path], files_b[file_path], diff_path)
 
     identical = all(diff.identical for diff in archives.values())
 

--- a/src/package_validation_tool/package/validation.py
+++ b/src/package_validation_tool/package/validation.py
@@ -323,11 +323,15 @@ def validate_package(
     install_build_deps: InstallationDecision = InstallationDecision.NO,
     autotools_dir: Optional[str] = None,
     apply_autotools: bool = True,
+    diffs_path: Optional[str] = None,
 ) -> bool:
     """Run analysis on a single package, and write report."""
 
     if package_type not in SUPPORTED_PACKAGE_TYPES:
         raise ValueError(f"Unsupported package type: {package_type}")
+
+    if diffs_path:
+        os.environ["PVT_FILE_MATCHER_DIFFS_PATH"] = diffs_path
 
     package_validation_result = validate_single_package(
         package,

--- a/test/test_diff_comparison.py
+++ b/test/test_diff_comparison.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for diff comparison functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from package_validation_tool.matching.diff_comparison import (
+    ArchiveDiffComparison,
+    DiffComparisonResult,
+    compare_diffs_directories,
+)
+
+
+def test_identical_diffs():
+    """Test that identical diffs directories are detected as identical."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_a = Path(tmpdir) / "a" / "pkg" / "pkg-1.0.tar.gz"
+        dir_b = Path(tmpdir) / "b" / "pkg" / "pkg-1.0.tar.gz"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        # Create identical diff files
+        (dir_a / "file.txt.arch").write_text("content")
+        (dir_a / "file.txt.repo").write_text("other")
+        (dir_b / "file.txt.arch").write_text("content")
+        (dir_b / "file.txt.repo").write_text("other")
+
+        result = compare_diffs_directories(
+            str(Path(tmpdir) / "a"),
+            str(Path(tmpdir) / "b"),
+            package_name="pkg",
+        )
+        assert result is True
+
+
+def test_different_content():
+    """Test that different file content is detected."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_a = Path(tmpdir) / "a" / "pkg" / "pkg-1.0.tar.gz"
+        dir_b = Path(tmpdir) / "b" / "pkg" / "pkg-1.0.tar.gz"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        # Create diff files with different content
+        (dir_a / "file.txt.arch").write_text("content_a")
+        (dir_b / "file.txt.arch").write_text("content_b")
+
+        result = compare_diffs_directories(
+            str(Path(tmpdir) / "a"),
+            str(Path(tmpdir) / "b"),
+            package_name="pkg",
+        )
+        assert result is False
+
+
+def test_file_only_in_one_dir():
+    """Test that files present in only one directory are detected."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_a = Path(tmpdir) / "a" / "pkg" / "pkg-1.0.tar.gz"
+        dir_b = Path(tmpdir) / "b" / "pkg" / "pkg-1.0.tar.gz"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        # File only in dir_a
+        (dir_a / "file.txt.arch").write_text("content")
+
+        result = compare_diffs_directories(
+            str(Path(tmpdir) / "a"),
+            str(Path(tmpdir) / "b"),
+            package_name="pkg",
+        )
+        assert result is False
+
+
+def test_json_output():
+    """Test that JSON output is written correctly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_a = Path(tmpdir) / "a" / "pkg" / "pkg-1.0.tar.gz"
+        dir_b = Path(tmpdir) / "b" / "pkg" / "pkg-1.0.tar.gz"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+
+        (dir_a / "file.txt.arch").write_text("a")
+        (dir_b / "file.txt.arch").write_text("b")
+
+        output_path = Path(tmpdir) / "result.json"
+        compare_diffs_directories(
+            str(Path(tmpdir) / "a"),
+            str(Path(tmpdir) / "b"),
+            package_name="pkg",
+            output_json_path=str(output_path),
+        )
+
+        assert output_path.exists()
+        with open(output_path, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["identical"] is False
+        assert "pkg-1.0.tar.gz" in data["archives_compared"]
+
+
+def test_nonexistent_directory():
+    """Test handling of nonexistent directories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = compare_diffs_directories(
+            str(Path(tmpdir) / "nonexistent_a"),
+            str(Path(tmpdir) / "nonexistent_b"),
+        )
+        assert result is False
+
+
+def test_empty_directories():
+    """Test comparison of empty directories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dir_a = Path(tmpdir) / "a"
+        dir_b = Path(tmpdir) / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        result = compare_diffs_directories(str(dir_a), str(dir_b))
+        assert result is True
+
+
+def test_archive_diff_comparison_identical():
+    """Test ArchiveDiffComparison.identical property."""
+    diff = ArchiveDiffComparison()
+    assert diff.identical is True
+
+    diff.files_only_in_a = ["file.txt"]
+    assert diff.identical is False
+
+
+def test_diff_comparison_result_post_init():
+    """Test DiffComparisonResult reconstructs nested objects from dicts."""
+    result = DiffComparisonResult(
+        identical=False,
+        package_name="pkg",
+        archives_compared=["archive.tar.gz"],
+        differences={"archive.tar.gz": {"files_only_in_a": ["test.txt"]}},
+    )
+    assert isinstance(result.differences["archive.tar.gz"], ArchiveDiffComparison)
+    assert result.differences["archive.tar.gz"].files_only_in_a == ["test.txt"]


### PR DESCRIPTION
When processing package updates, we want to understand the difference that was introduced with the update. This PR implements this update and allows to store the actual difference to disk. Then, this diff can be audited in addition to auditing the new version of the package.

### Testing Done

Tested the change on the curl package in Amazon Linux and the xz package in Fedora

#### Fedora

Collect data in Fedora container, then run comparison
```
# Validated xz-5.4.6-3.fc40 and xz-5.8.1-2.fc40
docker run --rm -t --network=host -v $PWD:$PWD -w $PWD -eHOME=$PWD \
    pvt-fedora40:test bash -c "
    python3 setup.py install &&
    package-validation-tool validate-package -p xz-5.4.6-3.fc40 \
        -o test-run/xz-v1.json --diffs-path test-run/diffs"
docker run --rm -t --network=host -v $PWD:$PWD -w $PWD -eHOME=$PWD \
    pvt-fedora40:test bash -c "
    python3 setup.py install &&
    package-validation-tool validate-package -p xz-5.8.1-2.fc40 \
        -o test-run/xz-v2.json --diffs-path test-run/diffs"
```

```
package-validation-tool compare-diffs \
    --dir-a test-run/diffs/xz-5.4.6-3.fc40/xz-5.4.6.tar.gz \
    --dir-b test-run/diffs/xz-5.8.1-2.fc40/xz-5.8.1.tar.gz \
    -o test-run/xz-comparison.json
```

#### Resulting Comparison Output

Differences are in Autotools-generated files due to different tool versions (Autoconf 2.71→2.72, Libtool 2.4.7→2.5.4)

Output from above comparison:

```
{
  "identical": false,
  "package_name": "",
  "archives_compared": [
    "ChangeLog",
    "build-aux",
    "configure",
    "m4",
    "po",
    "po4a"
  ],
  "differences": {
    "ChangeLog": {
      "files_only_in_a": [],
      "files_only_in_b": [],
      "files_with_different_content": []
    },
    "build-aux": {
      "files_only_in_a": [],
      "files_only_in_b": [],
      "files_with_different_content": [
        "build-aux/config.guess",
        "build-aux/config.sub",
        "build-aux/ltmain.sh"
      ]
    },
    "configure": {
      "files_only_in_a": [],
      "files_only_in_b": [],
      "files_with_different_content": [
        "configure"
      ]
    },
    "m4": {
      "files_only_in_a": [
        "m4/libtool.m4"
      ],
      "files_only_in_b": [],
      "files_with_different_content": [
        "m4/ltversion.m4"
      ]
    },
    "po": {
      "files_only_in_a": [
        "po/ca.po",
...
        "po/vi.po",
        "po/zh_CN.po",
        "po/zh_TW.po"
      ],
      "files_only_in_b": [],
      "files_with_different_content": []
    },
    "po4a": {
      "files_only_in_a": [
        "po4a/de.po",
...
        "po4a/uk.po"
      ],
      "files_only_in_b": [],
      "files_with_different_content": []
    }
  }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
