### PR TITLE
test,coverage: store commit in env var

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -37,8 +37,13 @@ jobs:
         echo "Base branch coverage: $BASE_COVERAGE%"
 
     - name: Get PR coverage
+      env:
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Bind the event-controlled SHA to an environment variable and
+        # reference it as a quoted shell variable, so it is never expanded
+        # into the script text (prevents GitHub Actions script injection).
       run: |
-        git checkout ${{ github.event.pull_request.head.sha }}
+        git checkout "$PR_HEAD_SHA"
         python -m pytest --cov-report=json:coverage-pr.json --tb=no -q
         PR_COVERAGE=$(python -c "import json; print(json.load(open('coverage-pr.json'))['totals']['percent_covered'])")
         echo "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV

--- a/src/package_validation_tool/operation_cache.py
+++ b/src/package_validation_tool/operation_cache.py
@@ -18,7 +18,9 @@ log = logging.getLogger(__name__)
 def data_to_return_type(func, data: dict):
     """Transform data in dictionary to object of function return type."""
     return_type = func.__annotations__.get("return")
-    if return_type and is_dataclass(return_type):
+    # is_dataclass() is true for both dataclass types and instances; require a
+    # type here so the call below is valid (and type-checkable as callable).
+    if return_type and isinstance(return_type, type) and is_dataclass(return_type):
         return return_type(**data)
     return data
 

--- a/test/system-level-testing.sh
+++ b/test/system-level-testing.sh
@@ -52,7 +52,8 @@ recompile_package () (
     cp -r "$PROJECT_DIR"/* .
     rm -rf build
     echo "Building package ..." 1>&2
-    run_with_output_only_on_failure python3 setup.py install || status="$?"
+    # Install with pip (not the deprecated "setup.py install"/easy_install
+    run_with_output_only_on_failure python3 -m pip install . || status="$?"
 
     # Use exit, as this function is called in a subshell
     exit "$status"


### PR DESCRIPTION
To simplify storing the value, and improving safety of reusing it, store the pre-commit variable in an environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
